### PR TITLE
Adding a data dump for when discard and fill fails 

### DIFF
--- a/file_io.py
+++ b/file_io.py
@@ -502,6 +502,17 @@ def write_netcdf_basic (data, var_name, filename, time_dependent=True, units=Non
     id.variables[var_name][:] = data
     id.close()
 
+# Save a very basic NetCDF file as an error dump from the discard_and_fill function
+def write_netcdf_error_discard_fill2D (data, discard, fill, filename):
+    import netCDF4 as nc
+    id = nc.Dataset(filename, 'w')
+    id.createDimension('Y', data.shape[-2])
+    id.createDimension('X', data.shape[-1])
+    id.createVariable(var_name, 'f8', ['Y', 'X'])
+    id.variables['data'][:] = data
+    id.variables['discard'][:] = discard
+    id.variables['fill'][:] = fill
+    id.close()
 
 # Given a list of output files (chronological, could concatenate to make the entire simulation) and a time index we want relative to the beginning of the simulation (0-indexed), find the individual file that time index falls within, and what that time index is relative to the beginning of that file.
 def find_time_index (file_list, time_index):

--- a/file_io.py
+++ b/file_io.py
@@ -508,7 +508,9 @@ def write_netcdf_error_discard_fill2D (data, discard, fill, filename):
     id = nc.Dataset(filename, 'w')
     id.createDimension('Y', data.shape[-2])
     id.createDimension('X', data.shape[-1])
-    id.createVariable(var_name, 'f8', ['Y', 'X'])
+    id.createVariable('data', 'f8', ['Y', 'X'])
+    id.createVariable('discard', 'f8', ['Y', 'X'])
+    id.createVariable('fill', 'f8', ['Y', 'X'])
     id.variables['data'][:] = data
     id.variables['discard'][:] = discard
     id.variables['fill'][:] = fill

--- a/file_io.py
+++ b/file_io.py
@@ -502,18 +502,20 @@ def write_netcdf_basic (data, var_name, filename, time_dependent=True, units=Non
     id.variables[var_name][:] = data
     id.close()
 
-# Save a very basic NetCDF file as an error dump from the discard_and_fill function
-def write_netcdf_error_discard_fill2D (data, discard, fill, filename):
+# Save a very basic NetCDF file with one variable as an error dump from the discard_and_fill function
+def write_netcdf_very_basic (data, var_name, filename, use_3d=False):
     import netCDF4 as nc
     id = nc.Dataset(filename, 'w')
-    id.createDimension('Y', data.shape[-2])
-    id.createDimension('X', data.shape[-1])
-    id.createVariable('data', 'f8', ['Y', 'X'])
-    id.createVariable('discard', 'f8', ['Y', 'X'])
-    id.createVariable('fill', 'f8', ['Y', 'X'])
-    id.variables['data'][:] = data
-    id.variables['discard'][:] = discard
-    id.variables['fill'][:] = fill
+    if use_3d:
+        id.createDimension('Z', data.shape[-3])
+        id.createDimension('Y', data.shape[-2])
+        id.createDimension('X', data.shape[-1])
+        id.createVariable(var_name, 'f8', ['Z', 'Y', 'X'])
+    else:
+        id.createDimension('Y', data.shape[-2])
+        id.createDimension('X', data.shape[-1])
+        id.createVariable(var_name, 'f8', ['Y', 'X'])
+    id.variables[var_name][:] = data
     id.close()
 
 # Given a list of output files (chronological, could concatenate to make the entire simulation) and a time index we want relative to the beginning of the simulation (0-indexed), find the individual file that time index falls within, and what that time index is relative to the beginning of that file.

--- a/ics_obcs.py
+++ b/ics_obcs.py
@@ -140,13 +140,10 @@ def sose_ics (grid_path, sose_dir, output_dir, bsose=False, nc_out=None, constan
 
     # Fields to interpolate
     fields = ['THETA', 'SALT', 'SIarea', 'SIheff']
-#   fields = ['SIarea', 'SIheff']
     # Flag for 2D or 3D
     dim = [3, 3, 2, 2]
-#   dim = [2, 2]
     # Constant values for ice shelf cavities
     constant_value = [constant_t, constant_s, 0, 0]
-#   constant_value = [0, 0]
     if bsose:
         # Add snow depth
         fields += ['SIhsnow']

--- a/ics_obcs.py
+++ b/ics_obcs.py
@@ -139,14 +139,14 @@ def sose_ics (grid_path, sose_dir, output_dir, bsose=False, nc_out=None, constan
     output_dir = real_dir(output_dir)
 
     # Fields to interpolate
-#   fields = ['THETA', 'SALT', 'SIarea', 'SIheff']
-    fields = ['SIarea', 'SIheff']
+    fields = ['THETA', 'SALT', 'SIarea', 'SIheff']
+#   fields = ['SIarea', 'SIheff']
     # Flag for 2D or 3D
-#   dim = [3, 3, 2, 2]
-    dim = [2, 2]
+    dim = [3, 3, 2, 2]
+#   dim = [2, 2]
     # Constant values for ice shelf cavities
-#   constant_value = [constant_t, constant_s, 0, 0]
-    constant_value = [0, 0]
+    constant_value = [constant_t, constant_s, 0, 0]
+#   constant_value = [0, 0]
     if bsose:
         # Add snow depth
         fields += ['SIhsnow']

--- a/ics_obcs.py
+++ b/ics_obcs.py
@@ -139,11 +139,14 @@ def sose_ics (grid_path, sose_dir, output_dir, bsose=False, nc_out=None, constan
     output_dir = real_dir(output_dir)
 
     # Fields to interpolate
-    fields = ['THETA', 'SALT', 'SIarea', 'SIheff']
+#   fields = ['THETA', 'SALT', 'SIarea', 'SIheff']
+    fields = ['SIarea', 'SIheff']
     # Flag for 2D or 3D
-    dim = [3, 3, 2, 2]
+#   dim = [3, 3, 2, 2]
+    dim = [2, 2]
     # Constant values for ice shelf cavities
-    constant_value = [constant_t, constant_s, 0, 0]
+#   constant_value = [constant_t, constant_s, 0, 0]
+    constant_value = [0, 0]
     if bsose:
         # Add snow depth
         fields += ['SIhsnow']

--- a/interpolation.py
+++ b/interpolation.py
@@ -349,7 +349,6 @@ def discard_and_fill (data, discard, fill, missing_val=-9999, use_1d=False, use_
                 print 'Error (discard_and_fill): some missing values cannot be filled'
                 print 'Dumping data, discard, and fill data to error_fill_dump.nc' 
                 fio.write_netcdf_very_basic(data,    'data',    'error_dump_data.nc', use_3d=use_3d)
-                from IPython import embed; embed()
                 fio.write_netcdf_very_basic(discard, 'discard', 'error_dump_discard.nc', use_3d=use_3d)
                 fio.write_netcdf_very_basic(fill,    'fill',    'error_dump_fill.nc', use_3d=use_3d)
                 sys.exit()

--- a/interpolation.py
+++ b/interpolation.py
@@ -449,7 +449,7 @@ def interp_bdry (source_h, source_z, source_data, source_hfac, target_h, target_
     # Extend all the way into the mask
     discard = source_hfac==0
     fill = np.ones(source_data.shape).astype(bool)
-    source_data = discard_and_fill(source_data, discard, fill, missing_val=missing_val, use_1d=(not depth_dependent), use_3d=False, log=False, grid=grid)
+    source_data = discard_and_fill(source_data, discard, fill, missing_val=missing_val, use_1d=(not depth_dependent), use_3d=False, log=False)
     
     # Interpolate
     if depth_dependent:

--- a/interpolation.py
+++ b/interpolation.py
@@ -345,11 +345,13 @@ def discard_and_fill (data, discard, fill, missing_val=-9999, use_1d=False, use_
                 if num_missing != num_missing_old:
                     break
             if num_missing == num_missing_old:
-                # If cannot complete discard and fill, write errors out to file (only 2D supported for now) 
+                # If cannot complete discard and fill, write errors out to very basic file 
                 print 'Error (discard_and_fill): some missing values cannot be filled'
-                if use_3d==False:
-                  print 'Dumping data, discard, and fill data to error_fill_dump.nc' 
-                  fio.write_netcdf_error_discard_fill2D(data, discard, fill, 'error_fill_dump.nc')
+                print 'Dumping data, discard, and fill data to error_fill_dump.nc' 
+                fio.write_netcdf_very_basic(data,    'data',    'error_dump_data.nc', use_3d=use_3d)
+                from IPython import embed; embed()
+                fio.write_netcdf_very_basic(discard, 'discard', 'error_dump_discard.nc', use_3d=use_3d)
+                fio.write_netcdf_very_basic(fill,    'fill',    'error_dump_fill.nc', use_3d=use_3d)
                 sys.exit()
     return data
 


### PR DESCRIPTION
Attempt to address issue https://github.com/knaughten/mitgcm_python/issues/7

I decided to try three very simple NetCDFs for error dumps. Along those lines, I've added a very basic NetCDF creator in the `file_io.py`. I decided to try this instead of using the existing functions because I didn't want to have to pass `grid` into `discard_and_fill`. Let me know what you think.  :)  